### PR TITLE
Extend transformations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utc-dt"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["date-and-time", "no-std", "parsing"]
 keywords = ["time", "datetime", "date", "utc", "epoch"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     let time_of_day_ns: u64 = utc_timestamp.as_time_of_day_ns();
     // Use UTC Timestamp to get days since epoch (ie. UTC Day)
     let utc_day: UTCDay = utc_timestamp.as_utc_day();
+    // Convert UTC Timestamp to a Duration to get millis since epoch.
+    let utc_millis = utc_timestamp.as_utc_duration().as_millis();
 
     // UTC Day from an integer
     let utc_day = UTCDay::from(19523);

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It prioritizes being space-optimal and efficient.
 [dependencies]
 utc-dt = "0.1"
 ```
-For extended/niche features and local timezone support see [`chrono`](https://github.com/chronotope/chrono) or [`time`](https://github.com/time-rs/time).
+For extended/niche features and local time-zone support see [`chrono`](https://github.com/chronotope/chrono) or [`time`](https://github.com/time-rs/time).
 
 ### NOTE
 Only capable of expressing times and dates SINCE the Unix Epoch `(1970-01-01T00:00:00Z)`. This library takes advantage of this assumption to simplify the API and internal logic.
@@ -47,16 +47,16 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     // Not available for #![no_std]
     let utc_timestamp = UTCTimestamp::try_from_system_time().unwrap();
     // UTC Timestamp from a u64 measurement directly.
-    let utc_timestamp = UTCTimestamp::from_millis(1686824288903);
+    let utc_timestamp: UTCTimestamp = Duration::from_millis(1686824288903).into();
     // Use UTC Timestamp to get time-of-day
-    let time_of_day_ns: u64 = utc_timestamp.to_time_of_day_ns();
+    let time_of_day_ns: u64 = utc_timestamp.as_time_of_day_ns();
     // Use UTC Timestamp to get days since epoch (ie. UTC Day)
-    let utc_day: UTCDay = utc_timestamp.to_utc_day();
+    let utc_day: UTCDay = utc_timestamp.as_utc_day();
 
     // UTC Day from an integer
     let utc_day = UTCDay::from(19523);
     // Use UTC Day to get the weekday
-    let weekday = utc_day.to_utc_weekday();
+    let weekday = utc_day.as_utc_weekday();
 
     // UTC Date directly from components
     let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap();
@@ -67,13 +67,13 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     // Get number of days within date's month
     let days_in_month: u8 = utc_date.days_in_month();
     // Get the date in integer forms
-    let (year, month, day) = (utc_date.year(), utc_date.month(), utc_date.day()); // OR
-    let (year, month, day) = utc_date.to_components();
+    let (year, month, day) = (utc_date.as_year(), utc_date.as_month(), utc_date.as_day()); // OR
+    let (year, month, day) = utc_date.as_components();
     // UTC Day from UTC Date
-    let utc_day = utc_date.to_utc_day();
+    let utc_day = utc_date.as_utc_day();
     // Get date string formatted according to ISO 8601 `(YYYY-MM-DD)`
     // Not available for #![no_std]
-    let iso_date = utc_date.to_iso_date();
+    let iso_date = utc_date.as_iso_date();
     assert_eq!(iso_date, "2023-06-15");
 
     // UTC Datetime directly from raw components
@@ -86,15 +86,15 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     // UTC Datetime from date and time-of-day components
     let utc_datetime = UTCDatetime::try_from_components(utc_date, time_of_day_ns).unwrap();
     // Get date and time-of-day components
-    let (utc_date, time_of_day_ns) = (utc_datetime.to_date(), utc_datetime.to_time_of_day_ns());
-    let (utc_date, time_of_day_ns) = utc_datetime.to_components();
+    let (utc_date, time_of_day_ns) = (utc_datetime.as_date(), utc_datetime.as_time_of_day_ns());
+    let (utc_date, time_of_day_ns) = utc_datetime.as_components();
     // Get the time in hours, minutes and seconds
-    let (hours, minutes, seconds) = utc_datetime.to_hours_minutes_seconds();
+    let (hours, minutes, seconds) = utc_datetime.as_hours_minutes_seconds();
     // Get the sub-second component of the time of day, in nanoseconds
-    let subsec_ns = utc_datetime.to_subsec_ns();
+    let subsec_ns = utc_datetime.as_subsec_ns();
     // Get UTC datetime string formatted according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
     // Not available for #![no_std]
-    let iso_datetime = utc_datetime.to_iso_datetime();
+    let iso_datetime = utc_datetime.as_iso_datetime();
     assert_eq!(iso_datetime, "2023-06-15T10:18:08Z");
 
     {
@@ -128,6 +128,14 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
         let utc_day = UTCDay::from_utc_secs(1_686_824_288);
         let utc_date = UTCDate::from_utc_millis(1_686_824_288_000);
         let utc_datetime = UTCDate::from_utc_micros(1_686_824_288_000_000);
+
+        // Convert from UTC Day / UTC Date / UTC Datetime back to various types
+        let utc_duration: Duration = utc_day.as_utc_duration();
+        let utc_timestamp: UTCTimestamp = utc_date.as_utc_timestamp();
+        let utc_secs: u64 = utc_date.as_utc_secs();
+        let utc_millis: u64 = utc_datetime.as_utc_millis();
+        let utc_micros: u64 = utc_day.as_utc_micros();
+        let utc_nanos: u64 = utc_date.as_utc_nanos();
     }
 ```
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -66,7 +66,7 @@ impl UTCDate {
     /// <http://howardhinnant.github.io/date_algorithms.html#days_from_civil>
     ///
     /// Simplified for unsigned days/years
-    pub fn to_utc_day(&self) -> UTCDay {
+    pub fn as_utc_day(&self) -> UTCDay {
         let m = self.month as u32;
         let d = self.day as u32;
         let y = self.year - ((m <= 2) as u32);
@@ -81,29 +81,29 @@ impl UTCDate {
     /// Get copy of the date components as integers
     ///
     /// Returns tuple: `(year: u32, month: u8, day: u8)`
-    pub fn to_components(&self) -> (u32, u8, u8) {
+    pub fn as_components(&self) -> (u32, u8, u8) {
         (self.year, self.month, self.day)
     }
 
     /// Consume self into date components as integers
     ///
     /// Returns tuple: `(year: u32, month: u8, day: u8)`
-    pub fn as_components(self) -> (u32, u8, u8) {
+    pub fn to_components(self) -> (u32, u8, u8) {
         (self.year, self.month, self.day)
     }
 
     /// Return day component of date
-    pub fn day(&self) -> u8 {
+    pub fn as_day(&self) -> u8 {
         self.day
     }
 
     /// Return month component of date
-    pub fn month(&self) -> u8 {
+    pub fn as_month(&self) -> u8 {
         self.month
     }
 
     /// Return year component of date
-    pub fn year(&self) -> u32 {
+    pub fn as_year(&self) -> u32 {
         self.year
     }
 
@@ -138,7 +138,7 @@ impl UTCDate {
     /// Conforms to ISO 8601:
     /// <https://www.w3.org/TR/NOTE-datetime>
     #[cfg(feature = "std")]
-    pub fn to_iso_date(&self) -> String {
+    pub fn as_iso_date(&self) -> String {
         format!("{:04}-{:02}-{:02}", self.year, self.month, self.day)
     }
 }
@@ -147,6 +147,10 @@ impl UTCTransformations for UTCDate {
     fn from_utc_timestamp(timestamp: UTCTimestamp) -> Self {
         let utc_day = UTCDay::from_utc_timestamp(timestamp);
         Self::from_utc_day(utc_day)
+    }
+
+    fn as_utc_timestamp(&self) -> UTCTimestamp {
+        self.as_utc_day().as_utc_timestamp()
     }
 }
 
@@ -241,7 +245,7 @@ mod test {
 
         for (expected, year, month, day) in test_cases {
             let date = UTCDate { year, month, day };
-            let utc_day = date.to_utc_day();
+            let utc_day = date.as_utc_day();
             assert_eq!(utc_day, expected);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! [dependencies]
 //! utc-dt = "0.1"
 //! ```
-//! For extended/niche features and local timezone support see [`chrono`](https://github.com/chronotope/chrono) or [`time`](https://github.com/time-rs/time).
+//! For extended/niche features and local time-zone support see [`chrono`](https://github.com/chronotope/chrono) or [`time`](https://github.com/time-rs/time).
 //!
 //! ### NOTE
 //! Only capable of expressing times and dates SINCE the Unix Epoch `(1970-01-01T00:00:00Z)`. This library takes advantage of this assumption to simplify the API and internal logic.
@@ -48,16 +48,16 @@
 //!     // Not available for #![no_std]
 //!     let utc_timestamp = UTCTimestamp::try_from_system_time().unwrap();
 //!     // UTC Timestamp from a u64 measurement directly.
-//!     let utc_timestamp = UTCTimestamp::from_millis(1686824288903);
+//!     let utc_timestamp: UTCTimestamp = Duration::from_millis(1686824288903).into();
 //!     // Use UTC Timestamp to get time-of-day
-//!     let time_of_day_ns: u64 = utc_timestamp.to_time_of_day_ns();
+//!     let time_of_day_ns: u64 = utc_timestamp.as_time_of_day_ns();
 //!     // Use UTC Timestamp to get days since epoch (ie. UTC Day)
-//!     let utc_day: UTCDay = utc_timestamp.to_utc_day();
+//!     let utc_day: UTCDay = utc_timestamp.as_utc_day();
 //!
 //!     // UTC Day from an integer
 //!     let utc_day = UTCDay::from(19523);
 //!     // Use UTC Day to get the weekday
-//!     let weekday = utc_day.to_utc_weekday();
+//!     let weekday = utc_day.as_utc_weekday();
 //!
 //!     // UTC Date directly from components
 //!     let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap();
@@ -68,13 +68,13 @@
 //!     // Get number of days within date's month
 //!     let days_in_month: u8 = utc_date.days_in_month();
 //!     // Get the date in integer forms
-//!     let (year, month, day) = (utc_date.year(), utc_date.month(), utc_date.day()); // OR
-//!     let (year, month, day) = utc_date.to_components();
+//!     let (year, month, day) = (utc_date.as_year(), utc_date.as_month(), utc_date.as_day()); // OR
+//!     let (year, month, day) = utc_date.as_components();
 //!     // UTC Day from UTC Date
-//!     let utc_day = utc_date.to_utc_day();
+//!     let utc_day = utc_date.as_utc_day();
 //!     // Get date string formatted according to ISO 8601 `(YYYY-MM-DD)`
 //!     // Not available with `no_std`
-//!     let iso_date = utc_date.to_iso_date();
+//!     let iso_date = utc_date.as_iso_date();
 //!     assert_eq!(iso_date, "2023-06-15");
 //!
 //!     // UTC Datetime directly from raw components
@@ -87,15 +87,15 @@
 //!     // UTC Datetime from date and time-of-day components
 //!     let utc_datetime = UTCDatetime::try_from_components(utc_date, time_of_day_ns).unwrap();
 //!     // Get date and time-of-day components
-//!     let (utc_date, time_of_day_ns) = (utc_datetime.to_date(), utc_datetime.to_time_of_day_ns());
-//!     let (utc_date, time_of_day_ns) = utc_datetime.to_components();
+//!     let (utc_date, time_of_day_ns) = (utc_datetime.as_date(), utc_datetime.as_time_of_day_ns());
+//!     let (utc_date, time_of_day_ns) = utc_datetime.as_components();
 //!     // Get the time in hours, minutes and seconds
-//!     let (hours, minutes, seconds) = utc_datetime.to_hours_minutes_seconds();
+//!     let (hours, minutes, seconds) = utc_datetime.as_hours_minutes_seconds();
 //!     // Get the sub-second component of the time of day, in nanoseconds
-//!     let subsec_ns = utc_datetime.to_subsec_ns();
+//!     let subsec_ns = utc_datetime.as_subsec_ns();
 //!     // Get UTC datetime string formatted according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
 //!     // Not available with `no_std`
-//!     let iso_datetime = utc_datetime.to_iso_datetime();
+//!     let iso_datetime = utc_datetime.as_iso_datetime();
 //!     assert_eq!(iso_datetime, "2023-06-15T10:18:08Z");
 //!
 //!     {
@@ -129,6 +129,14 @@
 //!         let utc_day = UTCDay::from_utc_secs(1686824288);
 //!         let utc_date = UTCDate::from_utc_millis(1686824288_000);
 //!         let utc_datetime = UTCDate::from_utc_micros(1686824288_000_000);
+//!
+//!         // Convert from UTC Day / UTC Date / UTC Datetime back to various types
+//!         let utc_duration: Duration = utc_day.as_utc_duration();
+//!         let utc_timestamp: UTCTimestamp = utc_date.as_utc_timestamp();
+//!         let utc_secs: u64 = utc_date.as_utc_secs();
+//!         let utc_millis: u64 = utc_datetime.as_utc_millis();
+//!         let utc_micros: u64 = utc_day.as_utc_micros();
+//!         let utc_nanos: u64 = utc_date.as_utc_nanos();
 //!     }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //!     let time_of_day_ns: u64 = utc_timestamp.as_time_of_day_ns();
 //!     // Use UTC Timestamp to get days since epoch (ie. UTC Day)
 //!     let utc_day: UTCDay = utc_timestamp.as_utc_day();
+//!     // Convert UTC Timestamp to a Duration to get millis since epoch.
+//!     let utc_millis = utc_timestamp.as_utc_duration().as_millis();
 //!
 //!     // UTC Day from an integer
 //!     let utc_day = UTCDay::from(19523);

--- a/src/time.rs
+++ b/src/time.rs
@@ -49,12 +49,12 @@ impl UTCTimestamp {
     }
 
     /// UTC Timestamp as a Duration since the Unix Epoch.
-    pub fn as_duration(&self) -> Duration {
+    pub fn as_utc_duration(&self) -> Duration {
         self.0
     }
 
     /// Consume UTC Timestamp into a Duration since the Unix Epoch.
-    pub fn to_duration(self) -> Duration {
+    pub fn to_utc_duration(self) -> Duration {
         self.0
     }
 


### PR DESCRIPTION
Adds further options for converting between types. Methods have been added/tweaked to be more intuitive and backwards conversion methods `(as_...)` have been added to `UTCTransformations.`

Also, all `UTCTimestamp` methods that simply wrapped `Duration` methods have been removed. The user is now expected to convert the `UTCTimestamp` to a `Duration` and use these methods directly.

For example:
```rust
let utc_timestamp = UTCTimestamp::try_from_system_time()?;
let utc_millis = utc_timestamp.as_utc_duration().as_millis();
```
