### PR TITLE
Better Day & Date base unit transformations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utc-dt"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["date-and-time", "no-std", "parsing"]
 keywords = ["time", "datetime", "date", "utc", "epoch"]

--- a/src/date.rs
+++ b/src/date.rs
@@ -144,6 +144,42 @@ impl UTCDate {
 }
 
 impl UTCTransformations for UTCDate {
+    fn from_utc_secs(s: u64) -> Self {
+        let utc_day = UTCDay::from_utc_secs(s);
+        Self::from_utc_day(utc_day)
+    }
+
+    fn as_utc_secs(&self) -> u64 {
+        self.as_utc_day().as_utc_secs()
+    }
+
+    fn from_utc_millis(s: u64) -> Self {
+        let utc_day = UTCDay::from_utc_millis(s);
+        Self::from_utc_day(utc_day)
+    }
+
+    fn as_utc_millis(&self) -> u64 {
+        self.as_utc_day().as_utc_millis()
+    }
+
+    fn from_utc_micros(s: u64) -> Self {
+        let utc_day = UTCDay::from_utc_micros(s);
+        Self::from_utc_day(utc_day)
+    }
+
+    fn as_utc_micros(&self) -> u64 {
+        self.as_utc_day().as_utc_micros()
+    }
+
+    fn from_utc_nanos(s: u64) -> Self {
+        let utc_day = UTCDay::from_utc_nanos(s);
+        Self::from_utc_day(utc_day)
+    }
+
+    fn as_utc_nanos(&self) -> u64 {
+        self.as_utc_day().as_utc_nanos()
+    }
+
     fn from_utc_timestamp(timestamp: UTCTimestamp) -> Self {
         let utc_day = UTCDay::from_utc_timestamp(timestamp);
         Self::from_utc_day(utc_day)

--- a/src/time.rs
+++ b/src/time.rs
@@ -181,6 +181,38 @@ impl UTCDay {
 }
 
 impl UTCTransformations for UTCDay {
+    fn from_utc_secs(s: u64) -> Self {
+        Self((s / SECONDS_PER_DAY) as u32)
+    }
+
+    fn as_utc_secs(&self) -> u64 {
+        (self.0 as u64) * SECONDS_PER_DAY
+    }
+
+    fn from_utc_millis(ms: u64) -> Self {
+        Self((ms / MILLIS_PER_DAY) as u32)
+    }
+
+    fn as_utc_millis(&self) -> u64 {
+        (self.0 as u64) * MILLIS_PER_DAY
+    }
+
+    fn from_utc_micros(us: u64) -> Self {
+        Self((us / MICROS_PER_DAY) as u32)
+    }
+
+    fn as_utc_micros(&self) -> u64 {
+        (self.0 as u64) * MICROS_PER_DAY
+    }
+
+    fn from_utc_nanos(ns: u64) -> Self {
+        Self((ns / NANOS_PER_DAY) as u32)
+    }
+
+    fn as_utc_nanos(&self) -> u64 {
+        (self.0 as u64) * NANOS_PER_DAY
+    }
+
     fn from_utc_timestamp(timestamp: UTCTimestamp) -> Self {
         timestamp.as_utc_day()
     }


### PR DESCRIPTION
Overrides `UTCTransformations`' methods on `UTCDate` and `UTCDay` for increased performance when converting to/from base time units (seconds , millis, micros & nanos)