### PR TITLE
Compiler Hints, Optimisations and Timestamp Shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UTC Datetime
 Simple, fast and small UTC date, timestamp and datetime library for Rust.
 
-UTC Datetime aims to be a user friendly date and time alternative, focused on core features.
+UTC Datetime aims to be ergonomic and user friendly, focused on core features.
 It prioritizes being space-optimal and efficient.
 
 ```toml
@@ -10,8 +10,9 @@ utc-dt = "0.1"
 ```
 For extended/niche features and local time-zone support see [`chrono`](https://github.com/chronotope/chrono) or [`time`](https://github.com/time-rs/time).
 
-### NOTE
-Only capable of expressing times and dates SINCE the Unix Epoch `(1970-01-01T00:00:00Z)`. This library takes advantage of this assumption to simplify the API and internal logic.
+### `unsigned` only!
+UTC Datetime will only express times and dates SINCE the Unix Epoch `(1970-01-01T00:00:00Z)`.
+The library takes advantage of this assumption to simplify the API and internal logic.
 
 ## Documentation
 See [docs.rs](https://docs.rs/utc-dt) for the API reference.
@@ -42,26 +43,32 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     let example_duration = Duration::from_millis(1686824288903);
 
     // UTC Timestamp from a duration
-    let utc_timestamp = UTCTimestamp::from(example_duration);
+    let utc_timestamp = UTCTimestamp::from(example_duration); // OR
+    let utc_timestamp = UTCTimestamp::from_utc_duration(example_duration);
     // UTC timestamp from the local system time.
     // Not available for #![no_std]
     let utc_timestamp = UTCTimestamp::try_from_system_time().unwrap();
-    // UTC Timestamp from a u64 measurement directly.
-    let utc_timestamp: UTCTimestamp = Duration::from_millis(1686824288903).into();
+    // UTC Timestamp from a time measurement (for secs, millis, micros, nanos)
+    let utc_timestamp = UTCTimestamp::from_utc_millis(1686824288903);
+    // Use UTC Timestamp to get a time measurement since the epoch (for secs, millis, micros, nanos)
+    let utc_millis = utc_timestamp.as_utc_millis();
     // Use UTC Timestamp to get time-of-day
     let time_of_day_ns: u64 = utc_timestamp.as_time_of_day_ns();
     // Use UTC Timestamp to get days since epoch (ie. UTC Day)
     let utc_day: UTCDay = utc_timestamp.as_utc_day();
-    // Convert UTC Timestamp to a Duration to get millis since epoch.
-    let utc_millis = utc_timestamp.as_utc_duration().as_millis();
+    // UTC Timestamp from a UTC Day and time-of-day components
+    let utc_timestamp = UTCTimestamp::try_from_days_and_nanos(utc_day, time_of_day_ns).unwrap(); // OR
+    let utc_timestamp = unsafe { UTCTimestamp::from_days_and_nanos(utc_day, time_of_day_ns) };
 
     // UTC Day from an integer
-    let utc_day = UTCDay::from(19523);
+    let utc_day = UTCDay::from(19523); // OR
+    let utc_day = UTCDay::from_u32(19523);
     // Use UTC Day to get the weekday
     let weekday = utc_day.as_utc_weekday();
 
     // UTC Date directly from components
-    let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap();
+    let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap(); // OR
+    let utc_date = unsafe { UTCDate::from_components(2023, 6, 15) };
     // UTC Date from UTC Day
     let utc_date = UTCDate::from_utc_day(utc_day);
     // Check whether date occurs within leap year
@@ -84,9 +91,16 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
         month,
         day,
         time_of_day_ns
-    ).unwrap();
+    ).unwrap(); // OR
+    let utc_datetime = unsafe { UTCDatetime::from_raw_components(
+        year,
+        month,
+        day,
+        time_of_day_ns
+    )};
     // UTC Datetime from date and time-of-day components
-    let utc_datetime = UTCDatetime::try_from_components(utc_date, time_of_day_ns).unwrap();
+    let utc_datetime = UTCDatetime::try_from_components(utc_date, time_of_day_ns).unwrap(); // OR
+    let utc_datetime = unsafe { UTCDatetime::from_components(utc_date, time_of_day_ns) };
     // Get date and time-of-day components
     let (utc_date, time_of_day_ns) = (utc_datetime.as_date(), utc_datetime.as_time_of_day_ns());
     let (utc_date, time_of_day_ns) = utc_datetime.as_components();
@@ -95,7 +109,7 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     // Get the sub-second component of the time of day, in nanoseconds
     let subsec_ns = utc_datetime.as_subsec_ns();
     // Get UTC datetime string formatted according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
-    // Not available for #![no_std]
+    // Not available with `no_std`
     let iso_datetime = utc_datetime.as_iso_datetime();
     assert_eq!(iso_datetime, "2023-06-15T10:18:08Z");
 
@@ -127,9 +141,9 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
         let utc_datetime = UTCDatetime::try_from_system_time().unwrap();
 
         // UTC Day / UTC Date / UTC Datetime from u64 epoch measurements
-        let utc_day = UTCDay::from_utc_secs(1_686_824_288);
-        let utc_date = UTCDate::from_utc_millis(1_686_824_288_000);
-        let utc_datetime = UTCDate::from_utc_micros(1_686_824_288_000_000);
+        let utc_day = UTCDay::from_utc_secs(1686824288);
+        let utc_date = UTCDate::from_utc_millis(1686824288_000);
+        let utc_datetime = UTCDate::from_utc_micros(1686824288_000_000);
 
         // Convert from UTC Day / UTC Date / UTC Datetime back to various types
         let utc_duration: Duration = utc_day.as_utc_duration();

--- a/src/date.rs
+++ b/src/date.rs
@@ -20,17 +20,28 @@ pub struct UTCDate {
 }
 
 impl UTCDate {
+    const fn _from_components_unchecked(year: u32, month: u8, day: u8) -> Self {
+        Self { year, month, day }
+    }
+
+    /// Unchecked method to create a UTC Date from provided year, month and day.
+    #[inline]
+    pub const unsafe fn from_components(year: u32, month: u8, day: u8) -> Self {
+        Self::_from_components_unchecked(year, month, day)
+    }
+
     /// Try to create a UTC Date from provided year, month and day.
     pub fn try_from_components(year: u32, month: u8, day: u8) -> Result<Self> {
         // force create
-        let date = Self { year, month, day };
+        let date = Self::_from_components_unchecked(year, month, day);
+        // then check
         if date.year < 1970 {
             return Err(anyhow!("Year out of range! (year: {:04})", year));
         }
         if date.month == 0 || date.month > 12 {
             return Err(anyhow!("Month out of range! (month: {:02})", month));
         }
-        if date.day == 0 || date.day > date.days_in_month() {
+        if date.day == 0 || date.day > date.days_in_month()? {
             return Err(anyhow!(
                 "Day out of range! (day: {:02}) (yyyy-mm: {:04}-{:02})",
                 day,
@@ -47,8 +58,8 @@ impl UTCDate {
     /// <http://howardhinnant.github.io/date_algorithms.html#civil_from_days>
     ///
     /// Simplified for unsigned days/years
-    pub fn from_utc_day(utc_day: UTCDay) -> Self {
-        let z = u32::from(utc_day) + 719468;
+    pub const fn from_utc_day(utc_day: UTCDay) -> Self {
+        let z = utc_day.as_u32() + 719468;
         let era = z / 146097;
         let doe = z - (era * 146097);
         let yoe = (doe - (doe / 1460) + (doe / 36524) - (doe / 146096)) / 365;
@@ -66,7 +77,7 @@ impl UTCDate {
     /// <http://howardhinnant.github.io/date_algorithms.html#days_from_civil>
     ///
     /// Simplified for unsigned days/years
-    pub fn as_utc_day(&self) -> UTCDay {
+    pub const fn as_utc_day(&self) -> UTCDay {
         let m = self.month as u32;
         let d = self.day as u32;
         let y = self.year - ((m <= 2) as u32);
@@ -75,35 +86,40 @@ impl UTCDate {
         let doy = ((153 * (if m > 2 { m - 3 } else { m + 9 }) + 2) / 5) + d - 1;
         let doe = (yoe * 365) + (yoe / 4) - (yoe / 100) + doy;
         let days = (era * 146097) + doe - 719468;
-        days.into()
+        UTCDay::from_u32(days)
     }
 
     /// Get copy of the date components as integers
     ///
     /// Returns tuple: `(year: u32, month: u8, day: u8)`
-    pub fn as_components(&self) -> (u32, u8, u8) {
+    #[inline]
+    pub const fn as_components(&self) -> (u32, u8, u8) {
         (self.year, self.month, self.day)
     }
 
     /// Consume self into date components as integers
     ///
     /// Returns tuple: `(year: u32, month: u8, day: u8)`
-    pub fn to_components(self) -> (u32, u8, u8) {
+    #[inline]
+    pub const fn to_components(self) -> (u32, u8, u8) {
         (self.year, self.month, self.day)
     }
 
     /// Return day component of date
-    pub fn as_day(&self) -> u8 {
+    #[inline]
+    pub const fn as_day(&self) -> u8 {
         self.day
     }
 
     /// Return month component of date
-    pub fn as_month(&self) -> u8 {
+    #[inline]
+    pub const fn as_month(&self) -> u8 {
         self.month
     }
 
     /// Return year component of date
-    pub fn as_year(&self) -> u32 {
+    #[inline]
+    pub const fn as_year(&self) -> u32 {
         self.year
     }
 
@@ -111,24 +127,25 @@ impl UTCDate {
     ///
     /// Reference:
     /// <http://howardhinnant.github.io/date_algorithms.html#is_leap>
-    pub fn is_leap_year(&self) -> bool {
+    #[inline]
+    pub const fn is_leap_year(&self) -> bool {
         (self.year % 4 == 0) && ((self.year % 100 != 0) || (self.year % 400 == 0))
     }
 
     /// Returns the number of days within the month of the date.
     /// Leap years are accounted for.
-    pub fn days_in_month(&self) -> u8 {
+    pub fn days_in_month(&self) -> Result<u8> {
         match self.month {
-            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
-            4 | 6 | 9 | 11 => 30,
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => Ok(31),
+            4 | 6 | 9 | 11 => Ok(30),
             2 => {
                 if self.is_leap_year() {
-                    29
+                    Ok(29)
                 } else {
-                    28
+                    Ok(28)
                 }
             }
-            _ => panic!("Month out of range! {:2}", self.month),
+            _ => Err(anyhow!("Month out of range! {:2}", self.month)),
         }
     }
 
@@ -138,6 +155,7 @@ impl UTCDate {
     /// Conforms to ISO 8601:
     /// <https://www.w3.org/TR/NOTE-datetime>
     #[cfg(feature = "std")]
+    #[inline]
     pub fn as_iso_date(&self) -> String {
         format!("{:04}-{:02}-{:02}", self.year, self.month, self.day)
     }
@@ -280,7 +298,7 @@ mod test {
         ];
 
         for (expected, year, month, day) in test_cases {
-            let date = UTCDate { year, month, day };
+            let date = UTCDate::try_from_components(year, month, day)?;
             let utc_day = date.as_utc_day();
             assert_eq!(utc_day, expected);
         }

--- a/src/date.rs
+++ b/src/date.rs
@@ -25,6 +25,10 @@ impl UTCDate {
     }
 
     /// Unchecked method to create a UTC Date from provided year, month and day.
+    ///
+    /// # Safety
+    /// Unsafe if the user passes an invalid calendar year, month and day combination.
+    /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
     pub const unsafe fn from_components(year: u32, month: u8, day: u8) -> Self {
         Self::_from_components_unchecked(year, month, day)

--- a/src/date.rs
+++ b/src/date.rs
@@ -20,24 +20,20 @@ pub struct UTCDate {
 }
 
 impl UTCDate {
-    const fn _from_components_unchecked(year: u32, month: u8, day: u8) -> Self {
-        Self { year, month, day }
-    }
-
     /// Unchecked method to create a UTC Date from provided year, month and day.
     ///
     /// # Safety
     /// Unsafe if the user passes an invalid calendar year, month and day combination.
     /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
-    pub const unsafe fn from_components(year: u32, month: u8, day: u8) -> Self {
-        Self::_from_components_unchecked(year, month, day)
+    pub const unsafe fn from_components_unchecked(year: u32, month: u8, day: u8) -> Self {
+        Self { year, month, day }
     }
 
     /// Try to create a UTC Date from provided year, month and day.
     pub fn try_from_components(year: u32, month: u8, day: u8) -> Result<Self> {
         // force create
-        let date = Self::_from_components_unchecked(year, month, day);
+        let date = unsafe { Self::from_components_unchecked(year, month, day) };
         // then check
         if date.year < 1970 {
             return Err(anyhow!("Year out of range! (year: {:04})", year));

--- a/src/date.rs
+++ b/src/date.rs
@@ -41,7 +41,7 @@ impl UTCDate {
         if date.month == 0 || date.month > 12 {
             return Err(anyhow!("Month out of range! (month: {:02})", month));
         }
-        if date.day == 0 || date.day > date.days_in_month()? {
+        if date.day == 0 || date.day > date.days_in_month() {
             return Err(anyhow!(
                 "Day out of range! (day: {:02}) (yyyy-mm: {:04}-{:02})",
                 day,
@@ -134,18 +134,18 @@ impl UTCDate {
 
     /// Returns the number of days within the month of the date.
     /// Leap years are accounted for.
-    pub fn days_in_month(&self) -> Result<u8> {
+    pub fn days_in_month(&self) -> u8 {
         match self.month {
-            1 | 3 | 5 | 7 | 8 | 10 | 12 => Ok(31),
-            4 | 6 | 9 | 11 => Ok(30),
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+            4 | 6 | 9 | 11 => 30,
             2 => {
                 if self.is_leap_year() {
-                    Ok(29)
+                    29
                 } else {
-                    Ok(28)
+                    28
                 }
             }
-            _ => Err(anyhow!("Month out of range! {:2}", self.month)),
+            _ => panic!("Month out of range! {:2}", self.month),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # UTC Datetime
 //! Simple, fast and small UTC date, timestamp and datetime library for Rust.
 //!
-//! UTC Datetime aims to be a user friendly date and time alternative, focused on core features.
+//! UTC Datetime aims to be ergonomic and user friendly, focused on core features.
 //! It prioritizes being space-optimal and efficient.
 //!
 //! ```rust,ignore
@@ -10,8 +10,9 @@
 //! ```
 //! For extended/niche features and local time-zone support see [`chrono`](https://github.com/chronotope/chrono) or [`time`](https://github.com/time-rs/time).
 //!
-//! ### NOTE
-//! Only capable of expressing times and dates SINCE the Unix Epoch `(1970-01-01T00:00:00Z)`. This library takes advantage of this assumption to simplify the API and internal logic.
+//! ### NOTE: `unsigned` only!
+//! UTC Datetime will only express times and dates SINCE the Unix Epoch `(1970-01-01T00:00:00Z)`.
+//! The library takes advantage of this assumption to simplify the API and internal logic.
 //!
 //! ## Documentation
 //! See [docs.rs](https://docs.rs/utc-dt) for the API reference.
@@ -26,7 +27,7 @@
 //! - Nanosecond resolution.
 //! - `#![no_std]` support.
 //!
-//! ## Example (exhaustive)
+//! ## Examples (exhaustive)
 #![cfg_attr(not(feature = "std"), doc = "```rust,ignore")]
 #![cfg_attr(feature = "std", doc = "```rust")]
 //!     use core::time::Duration;
@@ -43,26 +44,32 @@
 //!     let example_duration = Duration::from_millis(1686824288903);
 //!
 //!     // UTC Timestamp from a duration
-//!     let utc_timestamp = UTCTimestamp::from(example_duration);
+//!     let utc_timestamp = UTCTimestamp::from(example_duration); // OR
+//!     let utc_timestamp = UTCTimestamp::from_utc_duration(example_duration);
 //!     // UTC timestamp from the local system time.
 //!     // Not available for #![no_std]
 //!     let utc_timestamp = UTCTimestamp::try_from_system_time().unwrap();
-//!     // UTC Timestamp from a u64 measurement directly.
-//!     let utc_timestamp: UTCTimestamp = Duration::from_millis(1686824288903).into();
+//!     // UTC Timestamp from a time measurement (for secs, millis, micros, nanos)
+//!     let utc_timestamp = UTCTimestamp::from_utc_millis(1686824288903);
+//!     // Use UTC Timestamp to get a time measurement since the epoch (for secs, millis, micros, nanos)
+//!     let utc_millis = utc_timestamp.as_utc_millis();
 //!     // Use UTC Timestamp to get time-of-day
 //!     let time_of_day_ns: u64 = utc_timestamp.as_time_of_day_ns();
 //!     // Use UTC Timestamp to get days since epoch (ie. UTC Day)
 //!     let utc_day: UTCDay = utc_timestamp.as_utc_day();
-//!     // Convert UTC Timestamp to a Duration to get millis since epoch.
-//!     let utc_millis = utc_timestamp.as_utc_duration().as_millis();
+//!     // UTC Timestamp from a UTC Day and time-of-day components
+//!     let utc_timestamp = UTCTimestamp::try_from_days_and_nanos(utc_day, time_of_day_ns).unwrap(); // OR
+//!     let utc_timestamp = unsafe { UTCTimestamp::from_days_and_nanos(utc_day, time_of_day_ns) };
 //!
 //!     // UTC Day from an integer
-//!     let utc_day = UTCDay::from(19523);
+//!     let utc_day = UTCDay::from(19523); // OR
+//!     let utc_day = UTCDay::from_u32(19523);
 //!     // Use UTC Day to get the weekday
 //!     let weekday = utc_day.as_utc_weekday();
 //!
 //!     // UTC Date directly from components
-//!     let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap();
+//!     let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap(); // OR
+//!     let utc_date = unsafe { UTCDate::from_components(2023, 6, 15) };
 //!     // UTC Date from UTC Day
 //!     let utc_date = UTCDate::from_utc_day(utc_day);
 //!     // Check whether date occurs within leap year
@@ -75,7 +82,7 @@
 //!     // UTC Day from UTC Date
 //!     let utc_day = utc_date.as_utc_day();
 //!     // Get date string formatted according to ISO 8601 `(YYYY-MM-DD)`
-//!     // Not available with `no_std`
+//!     // Not available for #![no_std]
 //!     let iso_date = utc_date.as_iso_date();
 //!     assert_eq!(iso_date, "2023-06-15");
 //!
@@ -85,9 +92,16 @@
 //!         month,
 //!         day,
 //!         time_of_day_ns
-//!     ).unwrap();
+//!     ).unwrap(); // OR
+//!     let utc_datetime = unsafe { UTCDatetime::from_raw_components(
+//!         year,
+//!         month,
+//!         day,
+//!         time_of_day_ns
+//!     )};
 //!     // UTC Datetime from date and time-of-day components
-//!     let utc_datetime = UTCDatetime::try_from_components(utc_date, time_of_day_ns).unwrap();
+//!     let utc_datetime = UTCDatetime::try_from_components(utc_date, time_of_day_ns).unwrap(); // OR
+//!     let utc_datetime = unsafe { UTCDatetime::from_components(utc_date, time_of_day_ns) };
 //!     // Get date and time-of-day components
 //!     let (utc_date, time_of_day_ns) = (utc_datetime.as_date(), utc_datetime.as_time_of_day_ns());
 //!     let (utc_date, time_of_day_ns) = utc_datetime.as_components();
@@ -180,11 +194,17 @@ pub struct UTCDatetime {
 }
 
 impl UTCDatetime {
-    fn from_components(date: UTCDate, time_of_day_ns: u64) -> Self {
+    const fn _from_components(date: UTCDate, time_of_day_ns: u64) -> Self {
         Self {
             date,
             time_of_day_ns,
         }
+    }
+
+    /// Unchecked method to create a datetime frome date and time-of-day components.
+    #[inline]
+    pub const unsafe fn from_components(date: UTCDate, time_of_day_ns: u64) -> Self {
+        Self::_from_components(date, time_of_day_ns)
     }
 
     /// Try to create a datetime from date and time-of-day components.
@@ -195,7 +215,22 @@ impl UTCDatetime {
                 time_of_day_ns
             ));
         }
-        Ok(Self::from_components(date, time_of_day_ns))
+        Ok(Self::_from_components(date, time_of_day_ns))
+    }
+
+    /// Unchecked method to create datetime from underlying raw components
+    /// Will force create a `UTCDate` internally.
+    #[inline]
+    pub const unsafe fn from_raw_components(
+        year: u32,
+        month: u8,
+        day: u8,
+        time_of_day_ns: u64,
+    ) -> Self {
+        unsafe {
+            let date = UTCDate::from_components(year, month, day);
+            Self::from_components(date, time_of_day_ns)
+        }
     }
 
     /// Try to create a datetime from underlying raw components.
@@ -213,31 +248,36 @@ impl UTCDatetime {
     /// Get copy of the internal date and time-of-day components
     ///
     /// Returns tuple: `(date: UTCDate, time_of_day_ns: u64)`
-    pub fn as_components(&self) -> (UTCDate, u64) {
+    #[inline]
+    pub const fn as_components(&self) -> (UTCDate, u64) {
         (self.date, self.time_of_day_ns)
     }
 
     /// Consume self into the internal date and time-of-day components
     ///
     /// Returns tuple: `(date: UTCDate, time_of_day_ns: u64)`
-    pub fn to_components(self) -> (UTCDate, u64) {
+    #[inline]
+    pub const fn to_components(self) -> (UTCDate, u64) {
         (self.date, self.time_of_day_ns)
     }
 
     /// Get the internal date component.
-    pub fn as_date(&self) -> UTCDate {
+    #[inline]
+    pub const fn as_date(&self) -> UTCDate {
         self.date
     }
 
     /// Get the internal time-of-day component.
-    pub fn as_time_of_day_ns(&self) -> u64 {
+    #[inline]
+    pub const fn as_time_of_day_ns(&self) -> u64 {
         self.time_of_day_ns
     }
 
     /// Get the time-of-day expressed as hours minutes and seconds.
     ///
     /// Returns tuple `(hours: u8, minutes: u8, seconds: u8)`
-    pub fn as_hours_minutes_seconds(&self) -> (u8, u8, u8) {
+    #[inline]
+    pub const fn as_hours_minutes_seconds(&self) -> (u8, u8, u8) {
         let hours = (self.time_of_day_ns / NANOS_PER_HOUR) as u8;
         let minutes = ((self.time_of_day_ns % NANOS_PER_HOUR) / NANOS_PER_MINUTE) as u8;
         let seconds = ((self.time_of_day_ns % NANOS_PER_MINUTE) / NANOS_PER_SECOND) as u8;
@@ -246,7 +286,8 @@ impl UTCDatetime {
 
     /// Get the sub-second component of the time-of-day
     /// expressed in nanoseconds.
-    pub fn as_subsec_ns(&self) -> u32 {
+    #[inline]
+    pub const fn as_subsec_ns(&self) -> u32 {
         (self.time_of_day_ns % NANOS_PER_SECOND) as u32
     }
 
@@ -267,13 +308,13 @@ impl UTCTransformations for UTCDatetime {
     fn from_utc_timestamp(timestamp: UTCTimestamp) -> Self {
         let tod_ns = timestamp.as_time_of_day_ns();
         let date = UTCDate::from_utc_timestamp(timestamp);
-        Self::from_components(date, tod_ns)
+        unsafe { Self::from_components(date, tod_ns) }
     }
 
     fn as_utc_timestamp(&self) -> UTCTimestamp {
         let (date, tod_ns) = self.as_components();
         let day = date.as_utc_day();
-        UTCTimestamp::try_from_day_and_nanos(day, tod_ns).unwrap()
+        unsafe { UTCTimestamp::from_days_and_nanos(day, tod_ns) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,10 @@ impl UTCDatetime {
     }
 
     /// Unchecked method to create a datetime frome date and time-of-day components.
+    ///
+    /// # Safety
+    /// Unsafe if the user passes an invalid time-of-day nanoseconds component (exceeding NANOS_PER_DAY).
+    /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
     pub const unsafe fn from_components(date: UTCDate, time_of_day_ns: u64) -> Self {
         Self::_from_components(date, time_of_day_ns)
@@ -220,6 +224,11 @@ impl UTCDatetime {
 
     /// Unchecked method to create datetime from underlying raw components
     /// Will force create a `UTCDate` internally.
+    ///
+    /// # Safety
+    /// Unsafe if the user passes an invalid year-month-day combination or
+    /// time-of-day nanoseconds component (exceeding NANOS_PER_DAY).
+    /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
     pub const unsafe fn from_raw_components(
         year: u32,

--- a/src/time.rs
+++ b/src/time.rs
@@ -18,16 +18,23 @@ use crate::constants::*;
 pub struct UTCTimestamp(Duration);
 
 impl UTCTimestamp {
-    fn from_day_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
-        let secs = (day.0 as u64 * SECONDS_PER_DAY) + (time_of_day_ns / NANOS_PER_SECOND);
-        let nanos = (time_of_day_ns % NANOS_PER_SECOND) as u32;
-        Duration::new(secs, nanos).into()
+    /// Create a UTC Timestamp from UTC day
+    #[inline]
+    pub const fn from_day(day: UTCDay) -> Self {
+        let secs = day.0 as u64 * SECONDS_PER_DAY;
+        Self(Duration::from_secs(secs))
     }
 
-    /// Create a UTC Timestamp from UTC day
-    pub fn from_day(day: UTCDay) -> Self {
-        let secs = day.0 as u64 * SECONDS_PER_DAY;
-        Duration::from_secs(secs).into()
+    const fn _from_day_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
+        let secs = (day.0 as u64 * SECONDS_PER_DAY) + (time_of_day_ns / NANOS_PER_SECOND);
+        let nanos = (time_of_day_ns % NANOS_PER_SECOND) as u32;
+        Self(Duration::new(secs, nanos))
+    }
+
+    /// Unchecked method to create a UTC Timestamp from UTC day and time-of-day components
+    #[inline]
+    pub unsafe fn from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
+        Self::_from_day_and_nanos(day, time_of_day_ns)
     }
 
     /// Try to create a UTC Timestamp from UTC day and time-of-day components.
@@ -38,38 +45,91 @@ impl UTCTimestamp {
                 time_of_day_ns
             ));
         }
-        Ok(Self::from_day_and_nanos(day, time_of_day_ns))
+        Ok(Self::_from_day_and_nanos(day, time_of_day_ns))
     }
 
     /// Try to create a UTC Timestamp from the local system time.
     #[cfg(feature = "std")]
     pub fn try_from_system_time() -> Result<Self> {
         let duration = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?;
-        Ok(duration.into())
+        Ok(UTCTimestamp(duration))
     }
 
     /// UTC Timestamp as a Duration since the Unix Epoch.
-    pub fn as_utc_duration(&self) -> Duration {
+    #[inline]
+    pub const fn as_utc_duration(&self) -> Duration {
         self.0
     }
 
     /// Consume UTC Timestamp into a Duration since the Unix Epoch.
-    pub fn to_utc_duration(self) -> Duration {
+    #[inline]
+    pub const fn to_utc_duration(self) -> Duration {
         self.0
     }
 
     /// Get the UTC time-of-day in nanoseconds.
-    pub fn as_time_of_day_ns(&self) -> u64 {
+    #[inline]
+    pub const fn as_time_of_day_ns(&self) -> u64 {
         ((self.0.as_secs() % SECONDS_PER_DAY) * NANOS_PER_SECOND) + (self.0.subsec_nanos() as u64)
     }
 
     /// Get the number of UTC days since the Unix Epoch.
-    pub fn as_utc_day(&self) -> UTCDay {
-        ((self.0.as_secs() / SECONDS_PER_DAY) as u32).into()
+    #[inline]
+    pub const fn as_utc_day(&self) -> UTCDay {
+        UTCDay((self.0.as_secs() / SECONDS_PER_DAY) as u32)
+    }
+
+    /// Create UTC Timestamp from seconds since the Unix Epoch.
+    #[inline]
+    pub const fn from_utc_secs(s: u64) -> Self {
+        UTCTimestamp(Duration::from_secs(s))
+    }
+
+    /// Convert to seconds measured from the Unix Epoch.
+    #[inline]
+    pub const fn as_utc_secs(&self) -> u64 {
+        self.0.as_secs()
+    }
+
+    /// Create UTC Timestamp from milliseconds since the Unix Epoch.
+    #[inline]
+    pub const fn from_utc_millis(ms: u64) -> Self {
+        UTCTimestamp(Duration::from_millis(ms))
+    }
+
+    /// Convert to milliseconds measured from the Unix Epoch.
+    #[inline]
+    pub const fn as_utc_millis(&self) -> u64 {
+        self.0.as_millis() as u64
+    }
+
+    /// Create UTC Timestamp from microseconds since the Unix Epoch.
+    #[inline]
+    pub const fn from_utc_micros(us: u64) -> Self {
+        UTCTimestamp(Duration::from_micros(us))
+    }
+
+    /// Convert to microseconds measured from the Unix Epoch.
+    #[inline]
+    pub const fn as_utc_micros(&self) -> u64 {
+        self.0.as_micros() as u64
+    }
+
+    /// Create UTC Timestamp from nanoseconds since the Unix Epoch.
+    #[inline]
+    pub const fn from_utc_nanos(ns: u64) -> Self {
+        UTCTimestamp(Duration::from_nanos(ns))
+    }
+
+    /// Convert to seconds measured from the Unix Epoch.
+    #[inline]
+    pub const fn as_utc_nanos(&self) -> u64 {
+        self.0.as_nanos() as u64
     }
 }
 
 impl From<UTCDay> for UTCTimestamp {
+    #[inline]
     fn from(day: UTCDay) -> Self {
         UTCTimestamp::from_day(day)
     }
@@ -81,58 +141,68 @@ where
     Self: Sized,
 {
     /// Create from a duration measured from the Unix Epoch.
+    #[inline]
     fn from_utc_duration(duration: Duration) -> Self {
-        let timestamp = duration.into();
+        let timestamp = UTCTimestamp(duration);
         Self::from_utc_timestamp(timestamp)
     }
 
     /// Convert to a duration measured from the Unix Epoch.
+    #[inline]
     fn as_utc_duration(&self) -> Duration {
-        self.as_utc_timestamp().into()
+        self.as_utc_timestamp().as_utc_duration()
     }
 
     /// Create from seconds measured from the Unix Epoch.
+    #[inline]
     fn from_utc_secs(s: u64) -> Self {
-        let timestamp = Duration::from_secs(s).into();
+        let timestamp = UTCTimestamp::from_utc_secs(s);
         Self::from_utc_timestamp(timestamp)
     }
 
     /// Convert to seconds measured from the Unix Epoch.
+    #[inline]
     fn as_utc_secs(&self) -> u64 {
-        self.as_utc_duration().as_secs()
+        self.as_utc_timestamp().as_utc_secs()
     }
 
     /// Create from milliseconds measured from the Unix Epoch.
+    #[inline]
     fn from_utc_millis(ms: u64) -> Self {
-        let timestamp = Duration::from_millis(ms).into();
+        let timestamp = UTCTimestamp::from_utc_millis(ms);
         Self::from_utc_timestamp(timestamp)
     }
 
     /// Convert to milliseconds measured from the Unix Epoch.
+    #[inline]
     fn as_utc_millis(&self) -> u64 {
-        self.as_utc_duration().as_millis() as u64
+        self.as_utc_timestamp().as_utc_millis()
     }
 
-    /// Create from milliseconds measured from the Unix Epoch.
+    /// Create from microseconds measured from the Unix Epoch.
+    #[inline]
     fn from_utc_micros(us: u64) -> Self {
-        let timestamp = Duration::from_micros(us).into();
+        let timestamp = UTCTimestamp::from_utc_micros(us);
         Self::from_utc_timestamp(timestamp)
     }
 
     /// Convert to microseconds measured from the Unix Epoch.
+    #[inline]
     fn as_utc_micros(&self) -> u64 {
-        self.as_utc_duration().as_micros() as u64
+        self.as_utc_timestamp().as_utc_micros()
     }
 
     /// Create from nanoseconds measured from the Unix Epoch.
-    fn from_utc_nanos(ns: u64) -> Self {
-        let timestamp = Duration::from_nanos(ns).into();
+    #[inline]
+    fn from_utc_nanos(ms: u64) -> Self {
+        let timestamp = UTCTimestamp::from_utc_nanos(ms);
         Self::from_utc_timestamp(timestamp)
     }
 
     /// Convert to nanoseconds measured from the Unix Epoch.
+    #[inline]
     fn as_utc_nanos(&self) -> u64 {
-        self.as_utc_duration().as_nanos() as u64
+        self.as_utc_timestamp().as_utc_nanos()
     }
 
     /// Create from local system time
@@ -181,54 +251,66 @@ impl UTCDay {
 }
 
 impl UTCTransformations for UTCDay {
+    #[inline]
     fn from_utc_secs(s: u64) -> Self {
         Self((s / SECONDS_PER_DAY) as u32)
     }
 
+    #[inline]
     fn as_utc_secs(&self) -> u64 {
         (self.0 as u64) * SECONDS_PER_DAY
     }
 
+    #[inline]
     fn from_utc_millis(ms: u64) -> Self {
         Self((ms / MILLIS_PER_DAY) as u32)
     }
 
+    #[inline]
     fn as_utc_millis(&self) -> u64 {
         (self.0 as u64) * MILLIS_PER_DAY
     }
 
+    #[inline]
     fn from_utc_micros(us: u64) -> Self {
         Self((us / MICROS_PER_DAY) as u32)
     }
 
+    #[inline]
     fn as_utc_micros(&self) -> u64 {
         (self.0 as u64) * MICROS_PER_DAY
     }
 
+    #[inline]
     fn from_utc_nanos(ns: u64) -> Self {
         Self((ns / NANOS_PER_DAY) as u32)
     }
 
+    #[inline]
     fn as_utc_nanos(&self) -> u64 {
         (self.0 as u64) * NANOS_PER_DAY
     }
 
+    #[inline]
     fn from_utc_timestamp(timestamp: UTCTimestamp) -> Self {
         timestamp.as_utc_day()
     }
 
+    #[inline]
     fn as_utc_timestamp(&self) -> UTCTimestamp {
         UTCTimestamp::from_day(*self)
     }
 }
 
 impl From<Duration> for UTCDay {
+    #[inline]
     fn from(duration: Duration) -> Self {
         Self::from_utc_duration(duration)
     }
 }
 
 impl From<UTCTimestamp> for UTCDay {
+    #[inline]
     fn from(timestamp: UTCTimestamp) -> Self {
         Self::from_utc_timestamp(timestamp)
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -25,20 +25,16 @@ impl UTCTimestamp {
         Self(Duration::from_secs(secs))
     }
 
-    const fn _from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
-        let secs = (day.0 as u64 * SECONDS_PER_DAY) + (time_of_day_ns / NANOS_PER_SECOND);
-        let nanos = (time_of_day_ns % NANOS_PER_SECOND) as u32;
-        Self(Duration::new(secs, nanos))
-    }
-
     /// Unchecked method to create a UTC Timestamp from UTC day and time-of-day components
     ///
     /// # Safety
     /// Unsafe if the user passes an invalid time-of-day nanoseconds component (exceeding NANOS_PER_DAY).
     /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
-    pub const unsafe fn from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
-        Self::_from_days_and_nanos(day, time_of_day_ns)
+    pub const unsafe fn from_days_and_nanos_unchecked(day: UTCDay, time_of_day_ns: u64) -> Self {
+        let secs = (day.0 as u64 * SECONDS_PER_DAY) + (time_of_day_ns / NANOS_PER_SECOND);
+        let nanos = (time_of_day_ns % NANOS_PER_SECOND) as u32;
+        Self(Duration::new(secs, nanos))
     }
 
     /// Try to create a UTC Timestamp from UTC day and time-of-day components.
@@ -49,7 +45,7 @@ impl UTCTimestamp {
                 time_of_day_ns
             ));
         }
-        Ok(Self::_from_days_and_nanos(day, time_of_day_ns))
+        Ok(unsafe { Self::from_days_and_nanos_unchecked(day, time_of_day_ns) })
     }
 
     /// Try to create a UTC Timestamp from the local system time.

--- a/src/time.rs
+++ b/src/time.rs
@@ -25,7 +25,7 @@ impl UTCTimestamp {
         Self(Duration::from_secs(secs))
     }
 
-    const fn _from_day_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
+    const fn _from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
         let secs = (day.0 as u64 * SECONDS_PER_DAY) + (time_of_day_ns / NANOS_PER_SECOND);
         let nanos = (time_of_day_ns % NANOS_PER_SECOND) as u32;
         Self(Duration::new(secs, nanos))
@@ -34,18 +34,18 @@ impl UTCTimestamp {
     /// Unchecked method to create a UTC Timestamp from UTC day and time-of-day components
     #[inline]
     pub const unsafe fn from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
-        Self::_from_day_and_nanos(day, time_of_day_ns)
+        Self::_from_days_and_nanos(day, time_of_day_ns)
     }
 
     /// Try to create a UTC Timestamp from UTC day and time-of-day components.
-    pub fn try_from_day_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Result<Self> {
+    pub fn try_from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Result<Self> {
         if time_of_day_ns >= NANOS_PER_DAY {
             return Err(anyhow!(
                 "Nanoseconds not within a day! (time_of_day_ns: {})",
                 time_of_day_ns
             ));
         }
-        Ok(Self::_from_day_and_nanos(day, time_of_day_ns))
+        Ok(Self::_from_days_and_nanos(day, time_of_day_ns))
     }
 
     /// Try to create a UTC Timestamp from the local system time.
@@ -383,7 +383,7 @@ mod test {
         ];
 
         for (expected_timestamp, utc_days, time_of_day_ns, weekday) in test_cases {
-            let timestamp = UTCTimestamp::try_from_day_and_nanos(utc_days, time_of_day_ns)?;
+            let timestamp = UTCTimestamp::try_from_days_and_nanos(utc_days, time_of_day_ns)?;
             assert_eq!(timestamp, expected_timestamp);
             assert_eq!(UTCDay::from_utc_timestamp(timestamp), utc_days);
             assert_eq!(timestamp.as_time_of_day_ns(), time_of_day_ns);

--- a/src/time.rs
+++ b/src/time.rs
@@ -32,6 +32,10 @@ impl UTCTimestamp {
     }
 
     /// Unchecked method to create a UTC Timestamp from UTC day and time-of-day components
+    ///
+    /// # Safety
+    /// Unsafe if the user passes an invalid time-of-day nanoseconds component (exceeding NANOS_PER_DAY).
+    /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
     pub const unsafe fn from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
         Self::_from_days_and_nanos(day, time_of_day_ns)
@@ -355,7 +359,12 @@ mod test {
     fn test_from_days_and_nanos() -> Result<()> {
         let test_cases = [
             (UTCTimestamp::from_utc_nanos(0), UTCDay(0), 0, 4),
-            (UTCTimestamp::from_utc_nanos(123456789), UTCDay(0), 123456789, 4),
+            (
+                UTCTimestamp::from_utc_nanos(123456789),
+                UTCDay(0),
+                123456789,
+                4,
+            ),
             (
                 UTCTimestamp::from_utc_millis(1686756677000),
                 UTCDay(19522),
@@ -375,7 +384,10 @@ mod test {
                 3,
             ),
             (
-                UTCTimestamp::from_utc_duration(Duration::new(u32::MAX as u64 * SECONDS_PER_DAY, 0)),
+                UTCTimestamp::from_utc_duration(Duration::new(
+                    u32::MAX as u64 * SECONDS_PER_DAY,
+                    0,
+                )),
                 UTCDay(u32::MAX),
                 0,
                 0,

--- a/src/time.rs
+++ b/src/time.rs
@@ -33,7 +33,7 @@ impl UTCTimestamp {
 
     /// Unchecked method to create a UTC Timestamp from UTC day and time-of-day components
     #[inline]
-    pub unsafe fn from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
+    pub const unsafe fn from_days_and_nanos(day: UTCDay, time_of_day_ns: u64) -> Self {
         Self::_from_day_and_nanos(day, time_of_day_ns)
     }
 
@@ -55,13 +55,21 @@ impl UTCTimestamp {
         Ok(UTCTimestamp(duration))
     }
 
-    /// UTC Timestamp as a Duration since the Unix Epoch.
+    /// Create UTC Timestamp from a duration.
+    /// Constant evaluation alternative to `From<Duration>`.
+    #[inline]
+    pub const fn from_utc_duration(d: Duration) -> Self {
+        Self(d)
+    }
+
+    /// UTC Timestamp as internal Duration since the Unix Epoch.
     #[inline]
     pub const fn as_utc_duration(&self) -> Duration {
         self.0
     }
 
-    /// Consume UTC Timestamp into a Duration since the Unix Epoch.
+    /// Consume UTC Timestamp into the internal Duration since the Unix Epoch.
+    /// Constant evaluation alternative to `Into<Duration>`.
     #[inline]
     pub const fn to_utc_duration(self) -> Duration {
         self.0
@@ -240,6 +248,26 @@ where
 pub struct UTCDay(u32);
 
 impl UTCDay {
+    /// Create UTC Day from integer.
+    /// Const evaluation alternative to `From<u32>`
+    #[inline]
+    pub const fn from_u32(u: u32) -> Self {
+        Self(u)
+    }
+
+    /// UTC Day as internal integer
+    #[inline]
+    pub const fn as_u32(&self) -> u32 {
+        self.0
+    }
+
+    /// Consume UTC Day to internal integer
+    /// Const evaluation alternative to `Into<u32>`
+    #[inline]
+    pub const fn to_u32(self) -> u32 {
+        self.0
+    }
+
     /// Calculate and return the day of the week in numerical form
     /// `[0, 6]` represents `[Sun, Sat]`
     ///
@@ -347,7 +375,7 @@ mod test {
                 3,
             ),
             (
-                Duration::new(u32::MAX as u64 * SECONDS_PER_DAY, 0).into(),
+                UTCTimestamp::from_utc_duration(Duration::new(u32::MAX as u64 * SECONDS_PER_DAY, 0)),
                 UTCDay(u32::MAX),
                 0,
                 0,

--- a/src/time.rs
+++ b/src/time.rs
@@ -326,28 +326,28 @@ mod test {
     #[test]
     fn test_from_days_and_nanos() -> Result<()> {
         let test_cases = [
-            (Duration::from_nanos(0), UTCDay(0), 0, 4),
-            (Duration::from_nanos(123456789), UTCDay(0), 123456789, 4),
+            (UTCTimestamp::from_utc_nanos(0), UTCDay(0), 0, 4),
+            (UTCTimestamp::from_utc_nanos(123456789), UTCDay(0), 123456789, 4),
             (
-                Duration::from_millis(1686756677000),
+                UTCTimestamp::from_utc_millis(1686756677000),
                 UTCDay(19522),
                 55_877_000_000_000,
                 3,
             ),
             (
-                Duration::from_millis(1709220677000),
+                UTCTimestamp::from_utc_millis(1709220677000),
                 UTCDay(19782),
                 55_877_000_000_000,
                 4,
             ),
             (
-                Duration::from_millis(1677684677000),
+                UTCTimestamp::from_utc_millis(1677684677000),
                 UTCDay(19417),
                 55_877_000_000_000,
                 3,
             ),
             (
-                Duration::new(u32::MAX as u64 * SECONDS_PER_DAY, 0),
+                Duration::new(u32::MAX as u64 * SECONDS_PER_DAY, 0).into(),
                 UTCDay(u32::MAX),
                 0,
                 0,
@@ -356,7 +356,7 @@ mod test {
 
         for (expected_timestamp, utc_days, time_of_day_ns, weekday) in test_cases {
             let timestamp = UTCTimestamp::try_from_day_and_nanos(utc_days, time_of_day_ns)?;
-            assert_eq!(timestamp, expected_timestamp.into());
+            assert_eq!(timestamp, expected_timestamp);
             assert_eq!(UTCDay::from_utc_timestamp(timestamp), utc_days);
             assert_eq!(timestamp.as_time_of_day_ns(), time_of_day_ns);
             assert_eq!(utc_days.as_utc_weekday(), weekday);


### PR DESCRIPTION
Improves performance by explicitly detailing `#[inline]` and `const` functions where possible, as well as tweaking the execution of certain functions to use `const` methods where possible. This should result in faster execution, particularly when included in binaries not using link-time optimisation.

Adds unsafe `unchecked` alternative functions for many of the `try_from` creation methods. This provides the user with a faster option intended for use in hot-paths.

Re-introduces conversion shortcuts to/from various time measurements directly to `UTCTimestamp`. Previously these methods were removed as unnecessary redirection from the underlying `Duration` methods, however with the compiler hints this downside is alleviated.