### PR TITLE
Add math operators for `UTCTimestamp` and `UTCDay`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     let utc_timestamp = UTCTimestamp::from_day_and_tod(utc_day, utc_tod);
     // Manipulate UTC Timestamps with standard math operators
     assert_eq!(utc_timestamp + utc_timestamp, utc_timestamp * 2);
+    assert_eq!(utc_timestamp - example_duration, UTCTimestamp::ZERO);
     // Easily apply offsets of various measurements to timestamps
     let utc_timestamp_plus_1s = utc_timestamp.saturating_add_millis(1000);
     let utc_timestamp_minus_1s = utc_timestamp.saturating_sub_secs(1);

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
 - Determine the civil calendar date, time of day, weekday or the number of days since the Unix Epoch.
 - Obtain information on a date or time, such as if it occurs within a leap year, or the number of days in the month.
 - Convert between time representations efficiently and ergonomically.
-- Compile-time const evaluation wherever possible.
-- Format and parse dates according to ISO 8601 `(YYYY-MM-DD)`
-- Format and parse datetimes according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
+- Compile-time `const`` evaluation wherever possible.
+- Format and parse dates, times and datetimes according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
 - Provides constants useful for time transformations: [`utc-dt::constants`](https://docs.rs/utc-dt/latest/utc_dt/constants/index.html)
 - Nanosecond resolution.
+- Timestamps supporting standard math operators (`core::ops`)
 - `#![no_std]` support.
 
 ## Examples (exhaustive)
@@ -68,6 +68,11 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     let utc_day: UTCDay = utc_timestamp.as_day();
     // UTC Timestamp from UTC Day and time-of-day components
     let utc_timestamp = UTCTimestamp::from_day_and_tod(utc_day, utc_tod);
+    // Manipulate UTC Timestamps with standard math operators
+    assert_eq!(utc_timestamp + utc_timestamp, utc_timestamp * 2);
+    // Easily apply offsets of various measurements to timestamps
+    let utc_timestamp_plus_1s = utc_timestamp.saturating_add_millis(1000);
+    let utc_timestamp_minus_1s = utc_timestamp.saturating_sub_secs(1);
 
     // UTC Day from an integer
     let utc_day = UTCDay::try_from_u64(19523).unwrap();
@@ -76,6 +81,9 @@ See [docs.rs](https://docs.rs/utc-dt) for the API reference.
     let day_u64 = utc_day.to_u64();
     // Use UTC Day to get the weekday
     let weekday = utc_day.as_weekday();
+    // Manipulate UTC Days with standard math operators
+    assert_eq!(utc_day - utc_day, utc_day / u64::MAX);
+    assert_eq!(utc_day + 19523, utc_day * 2);
 
     // UTC Time of Day from a time measurement (for secs, millis, micros, nanos)
     let utc_tod = UTCTimeOfDay::try_from_millis(37088903).unwrap(); // OR

--- a/src/date.rs
+++ b/src/date.rs
@@ -246,8 +246,8 @@ impl UTCDate {
 }
 
 impl UTCTransformations for UTCDate {
-    fn from_secs(s: u64) -> Self {
-        let utc_day = UTCDay::from_secs(s);
+    fn from_secs(secs: u64) -> Self {
+        let utc_day = UTCDay::from_secs(secs);
         Self::from_day(utc_day)
     }
 
@@ -255,8 +255,8 @@ impl UTCTransformations for UTCDate {
         self.as_day().as_secs()
     }
 
-    fn from_millis(s: u64) -> Self {
-        let utc_day = UTCDay::from_millis(s);
+    fn from_millis(millis: u64) -> Self {
+        let utc_day = UTCDay::from_millis(millis);
         Self::from_day(utc_day)
     }
 
@@ -264,8 +264,8 @@ impl UTCTransformations for UTCDate {
         self.as_day().as_millis()
     }
 
-    fn from_micros(s: u64) -> Self {
-        let utc_day = UTCDay::from_micros(s);
+    fn from_micros(micros: u64) -> Self {
+        let utc_day = UTCDay::from_micros(micros);
         Self::from_day(utc_day)
     }
 
@@ -273,8 +273,8 @@ impl UTCTransformations for UTCDate {
         self.as_day().as_micros()
     }
 
-    fn from_nanos(s: u64) -> Self {
-        let utc_day = UTCDay::from_nanos(s);
+    fn from_nanos(nanos: u64) -> Self {
+        let utc_day = UTCDay::from_nanos(nanos);
         Self::from_day(utc_day)
     }
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -18,7 +18,14 @@ use crate::time::{UTCDay, UTCTimestamp, UTCTransformations};
 /// A UTC Date is any calendar date since the Unix epoch date (inclusive).
 ///
 /// ## Examples
-/// ```rust,ignore
+#[cfg_attr(not(feature = "std"), doc = "```rust,ignore")]
+#[cfg_attr(feature = "std", doc = "```rust")]
+/// use utc_dt::time::UTCDay;
+/// use utc_dt::date::UTCDate;
+///
+/// // UTC Day from an integer
+/// let utc_day = UTCDay::try_from_u64(19523).unwrap();
+///
 /// // UTC Date directly from components
 /// let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap(); // OR
 /// let utc_date = unsafe { UTCDate::from_components_unchecked(2023, 6, 15) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //!     let utc_timestamp = UTCTimestamp::from_day_and_tod(utc_day, utc_tod);
 //!     // Manipulate UTC Timestamps with standard math operators
 //!     assert_eq!(utc_timestamp + utc_timestamp, utc_timestamp * 2);
+//!     assert_eq!(utc_timestamp - example_duration, UTCTimestamp::ZERO);
 //!     // Easily apply offsets of various measurements to timestamps
 //!     let utc_timestamp_plus_1s = utc_timestamp.saturating_add_millis(1000);
 //!     let utc_timestamp_minus_1s = utc_timestamp.saturating_sub_secs(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,11 @@
 //! - Determine the civil calendar date, time of day, weekday or the number of days since the Unix Epoch.
 //! - Obtain information on a date or time, such as if it occurs within a leap year, or the number of days in the month.
 //! - Convert between time representations efficiently and ergonomically.
-//! - Compile-time const evaluation wherever possible.
-//! - Format and parse dates according to ISO 8601 `(YYYY-MM-DD)`
-//! - Format and parse datetimes according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
+//! - Compile-time `const` evaluation wherever possible.
+//! - Format and parse dates, times and datetimes according to ISO 8601 `(YYYY-MM-DDThh:mm:ssZ)`
 //! - Provides constants useful for time transformations: [`utc-dt::constants`](https://docs.rs/utc-dt/latest/utc_dt/constants/index.html)
 //! - Nanosecond resolution.
+//! - Timestamps supporting standard math operators (`core::ops`)
 //! - `#![no_std]` support.
 //!
 //! ## Examples (exhaustive)
@@ -69,6 +69,11 @@
 //!     let utc_day: UTCDay = utc_timestamp.as_day();
 //!     // UTC Timestamp from UTC Day and time-of-day components
 //!     let utc_timestamp = UTCTimestamp::from_day_and_tod(utc_day, utc_tod);
+//!     // Manipulate UTC Timestamps with standard math operators
+//!     assert_eq!(utc_timestamp + utc_timestamp, utc_timestamp * 2);
+//!     // Easily apply offsets of various measurements to timestamps
+//!     let utc_timestamp_plus_1s = utc_timestamp.saturating_add_millis(1000);
+//!     let utc_timestamp_minus_1s = utc_timestamp.saturating_sub_secs(1);
 //!
 //!     // UTC Day from an integer
 //!     let utc_day = UTCDay::try_from_u64(19523).unwrap();
@@ -77,6 +82,9 @@
 //!     let day_u64 = utc_day.to_u64();
 //!     // Use UTC Day to get the weekday
 //!     let weekday = utc_day.as_weekday();
+//!     // Manipulate UTC Days with standard math operators
+//!     assert_eq!(utc_day - utc_day, utc_day / u64::MAX);
+//!     assert_eq!(utc_day + 19523, utc_day * 2);
 //!
 //!     // UTC Time of Day from a time measurement (for secs, millis, micros, nanos)
 //!     let utc_tod = UTCTimeOfDay::try_from_millis(37088903).unwrap(); // OR
@@ -213,7 +221,17 @@ use time::{UTCTimeOfDay, UTCTimestamp, UTCTransformations};
 /// with nanosecond resolution.
 ///
 /// ## Examples
-/// ```rust,ignore
+#[cfg_attr(not(feature = "std"), doc = "```rust,ignore")]
+#[cfg_attr(feature = "std", doc = "```rust")]
+/// use utc_dt::time::UTCTimeOfDay;
+/// use utc_dt::date::UTCDate;
+/// use utc_dt::UTCDatetime;
+///
+/// // UTC Time of Day from a time measurement (for secs, millis, micros, nanos)
+/// let utc_tod = UTCTimeOfDay::try_from_millis(37088903).unwrap();
+/// // UTC Date directly from components
+/// let utc_date = UTCDate::try_from_components(2023, 6, 15).unwrap(); // OR
+///
 /// // UTC Datetime from date and time-of-day components
 /// let utc_datetime = UTCDatetime::from_components(utc_date, utc_tod);
 /// // Get date and time-of-day components

--- a/src/time.rs
+++ b/src/time.rs
@@ -114,8 +114,8 @@ impl UTCTimestamp {
 
     /// Create UTC Timestamp from seconds since the Unix Epoch.
     #[inline]
-    pub const fn from_secs(s: u64) -> Self {
-        UTCTimestamp(Duration::from_secs(s))
+    pub const fn from_secs(secs: u64) -> Self {
+        UTCTimestamp(Duration::from_secs(secs))
     }
 
     /// Convert to seconds measured from the Unix Epoch.
@@ -126,8 +126,8 @@ impl UTCTimestamp {
 
     /// Create UTC Timestamp from milliseconds since the Unix Epoch.
     #[inline]
-    pub const fn from_millis(ms: u64) -> Self {
-        UTCTimestamp(Duration::from_millis(ms))
+    pub const fn from_millis(millis: u64) -> Self {
+        UTCTimestamp(Duration::from_millis(millis))
     }
 
     /// Convert to milliseconds measured from the Unix Epoch.
@@ -138,8 +138,8 @@ impl UTCTimestamp {
 
     /// Create UTC Timestamp from microseconds since the Unix Epoch.
     #[inline]
-    pub const fn from_micros(us: u64) -> Self {
-        UTCTimestamp(Duration::from_micros(us))
+    pub const fn from_micros(micros: u64) -> Self {
+        UTCTimestamp(Duration::from_micros(micros))
     }
 
     /// Convert to microseconds measured from the Unix Epoch.
@@ -150,8 +150,8 @@ impl UTCTimestamp {
 
     /// Create UTC Timestamp from nanoseconds since the Unix Epoch.
     #[inline]
-    pub const fn from_nanos(ns: u64) -> Self {
-        UTCTimestamp(Duration::from_nanos(ns))
+    pub const fn from_nanos(nanos: u64) -> Self {
+        UTCTimestamp(Duration::from_nanos(nanos))
     }
 
     /// Convert to seconds measured from the Unix Epoch.
@@ -159,6 +159,8 @@ impl UTCTimestamp {
     pub const fn as_nanos(&self) -> u128 {
         self.0.as_nanos()
     }
+
+
 }
 
 impl From<Duration> for UTCTimestamp {
@@ -234,8 +236,8 @@ where
 
     /// Create from seconds measured from the Unix Epoch.
     #[inline]
-    fn from_secs(s: u64) -> Self {
-        let timestamp = UTCTimestamp::from_secs(s);
+    fn from_secs(secs: u64) -> Self {
+        let timestamp = UTCTimestamp::from_secs(secs);
         Self::from_timestamp(timestamp)
     }
 
@@ -247,8 +249,8 @@ where
 
     /// Create from milliseconds measured from the Unix Epoch.
     #[inline]
-    fn from_millis(ms: u64) -> Self {
-        let timestamp = UTCTimestamp::from_millis(ms);
+    fn from_millis(millis: u64) -> Self {
+        let timestamp = UTCTimestamp::from_millis(millis);
         Self::from_timestamp(timestamp)
     }
 
@@ -260,8 +262,8 @@ where
 
     /// Create from microseconds measured from the Unix Epoch.
     #[inline]
-    fn from_micros(us: u64) -> Self {
-        let timestamp = UTCTimestamp::from_micros(us);
+    fn from_micros(micros: u64) -> Self {
+        let timestamp = UTCTimestamp::from_micros(micros);
         Self::from_timestamp(timestamp)
     }
 
@@ -273,8 +275,8 @@ where
 
     /// Create from nanoseconds measured from the Unix Epoch.
     #[inline]
-    fn from_nanos(ms: u64) -> Self {
-        let timestamp = UTCTimestamp::from_nanos(ms);
+    fn from_nanos(nanos: u64) -> Self {
+        let timestamp = UTCTimestamp::from_nanos(nanos);
         Self::from_timestamp(timestamp)
     }
 
@@ -371,8 +373,8 @@ impl UTCDay {
 
 impl UTCTransformations for UTCDay {
     #[inline]
-    fn from_secs(s: u64) -> Self {
-        Self(s / SECONDS_PER_DAY)
+    fn from_secs(secs: u64) -> Self {
+        Self(secs / SECONDS_PER_DAY)
     }
 
     #[inline]
@@ -381,8 +383,8 @@ impl UTCTransformations for UTCDay {
     }
 
     #[inline]
-    fn from_millis(ms: u64) -> Self {
-        Self(ms / MILLIS_PER_DAY)
+    fn from_millis(millis: u64) -> Self {
+        Self(millis / MILLIS_PER_DAY)
     }
 
     #[inline]
@@ -391,8 +393,8 @@ impl UTCTransformations for UTCDay {
     }
 
     #[inline]
-    fn from_micros(us: u64) -> Self {
-        Self(us / MICROS_PER_DAY)
+    fn from_micros(micros: u64) -> Self {
+        Self(micros / MICROS_PER_DAY)
     }
 
     #[inline]
@@ -401,8 +403,8 @@ impl UTCTransformations for UTCDay {
     }
 
     #[inline]
-    fn from_nanos(ns: u64) -> Self {
-        Self(ns / NANOS_PER_DAY)
+    fn from_nanos(nanos: u64) -> Self {
+        Self(nanos / NANOS_PER_DAY)
     }
 
     #[inline]
@@ -505,8 +507,8 @@ impl UTCTimeOfDay {
     /// Unsafe if the user passes an invalid time-of-day nanoseconds component (exceeding NANOS_PER_DAY).
     /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
-    pub const unsafe fn from_nanos_unchecked(ns: u64) -> Self {
-        Self(ns)
+    pub const unsafe fn from_nanos_unchecked(nanos: u64) -> Self {
+        Self(nanos)
     }
 
     /// Unchecked method to create time of day from microseconds
@@ -515,8 +517,8 @@ impl UTCTimeOfDay {
     /// Unsafe if the user passes an invalid time-of-day microsecond component (exceeding MICROS_PER_DAY).
     /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
-    pub const unsafe fn from_micros_unchecked(us: u64) -> Self {
-        Self(us * NANOS_PER_MICRO)
+    pub const unsafe fn from_micros_unchecked(micros: u64) -> Self {
+        Self(micros * NANOS_PER_MICRO)
     }
 
     /// Unchecked method to create time of day from milliseconds
@@ -525,8 +527,8 @@ impl UTCTimeOfDay {
     /// Unsafe if the user passes an invalid time-of-day millisecond component (exceeding MILLIS_PER_DAY).
     /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
-    pub const unsafe fn from_millis_unchecked(ms: u32) -> Self {
-        Self((ms as u64) * NANOS_PER_MILLI)
+    pub const unsafe fn from_millis_unchecked(millis: u32) -> Self {
+        Self((millis as u64) * NANOS_PER_MILLI)
     }
 
     /// Unchecked method to create time of day from seconds
@@ -535,8 +537,8 @@ impl UTCTimeOfDay {
     /// Unsafe if the user passes an invalid time-of-day seconds component (exceeding SECONDS_PER_DAY).
     /// Invalid inputs are not checked and may cause a panic in other methods.
     #[inline]
-    pub const unsafe fn from_secs_unchecked(s: u32) -> Self {
-        Self((s as u64) * NANOS_PER_SECOND)
+    pub const unsafe fn from_secs_unchecked(secs: u32) -> Self {
+        Self((secs as u64) * NANOS_PER_SECOND)
     }
 
     const fn _ns_from_hhmmss(hrs: u8, mins: u8, secs: u8, subsec_ns: u32) -> u64 {
@@ -557,37 +559,37 @@ impl UTCTimeOfDay {
     }
 
     /// Try to create UTC time of day from nanoseconds
-    pub fn try_from_nanos(ns: u64) -> Result<Self> {
-        let tod = unsafe { Self::from_nanos_unchecked(ns) };
+    pub fn try_from_nanos(nanos: u64) -> Result<Self> {
+        let tod = unsafe { Self::from_nanos_unchecked(nanos) };
         if tod > Self::MAX {
-            bail!("Nanoseconds not within a day! (ns: {})", ns);
+            bail!("Nanoseconds not within a day! (nanos: {})", nanos);
         }
         Ok(tod)
     }
 
     /// Try to create UTC time of day from microseconds
-    pub fn try_from_micros(us: u64) -> Result<Self> {
-        let tod = unsafe { Self::from_micros_unchecked(us) };
+    pub fn try_from_micros(micros: u64) -> Result<Self> {
+        let tod = unsafe { Self::from_micros_unchecked(micros) };
         if tod > Self::MAX {
-            bail!("Microseconds not within a day! (us: {})", us);
+            bail!("Microseconds not within a day! (micros: {})", micros);
         }
         Ok(tod)
     }
 
     /// Try to create UTC time of day from milliseconds
-    pub fn try_from_millis(ms: u32) -> Result<Self> {
-        let tod = unsafe { Self::from_millis_unchecked(ms) };
+    pub fn try_from_millis(millis: u32) -> Result<Self> {
+        let tod = unsafe { Self::from_millis_unchecked(millis) };
         if tod > Self::MAX {
-            bail!("Milliseconds not within a day! (ms: {})", ms);
+            bail!("Milliseconds not within a day! (millis: {})", millis);
         }
         Ok(tod)
     }
 
     /// Try to create UTC time of day from seconds
-    pub fn try_from_secs(s: u32) -> Result<Self> {
-        let tod = unsafe { Self::from_secs_unchecked(s) };
+    pub fn try_from_secs(secs: u32) -> Result<Self> {
+        let tod = unsafe { Self::from_secs_unchecked(secs) };
         if tod > Self::MAX {
-            bail!("Seconds not within a day! (s: {})", s);
+            bail!("Seconds not within a day! (secs: {})", secs);
         }
         Ok(tod)
     }

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -109,7 +109,42 @@ fn test_utc_timestamp() -> Result<()> {
     assert_eq!(timestamp_copy, timestamp);
     assert_eq!(UTCTimestamp::ZERO, timestamp_copy.min(UTCTimestamp::ZERO));
     assert_eq!(UTCTimestamp::MAX, timestamp_copy.max(UTCTimestamp::MAX));
-
+    // test operation methods
+    assert_eq!(timestamp.saturating_add(UTCTimestamp::ZERO), timestamp);
+    assert_eq!(timestamp.saturating_add(UTCTimestamp::MAX), UTCTimestamp::MAX);
+    assert_eq!(timestamp.saturating_add_secs(0), timestamp);
+    assert_eq!(timestamp.saturating_add_secs(u64::MAX), UTCTimestamp::MAX);
+    assert_eq!(timestamp.saturating_add_millis(1000), timestamp.saturating_add_secs(1));
+    assert_eq!(timestamp.saturating_add_micros(1000), timestamp.saturating_add_millis(1));
+    assert_eq!(timestamp.saturating_add_nanos(1000), timestamp.saturating_add_micros(1));
+    assert_eq!(timestamp.saturating_sub(UTCTimestamp::ZERO), timestamp);
+    assert_eq!(timestamp.saturating_sub(UTCTimestamp::MAX), UTCTimestamp::ZERO);
+    assert_eq!(timestamp.saturating_sub_secs(0), timestamp);
+    assert_eq!(timestamp.saturating_sub_secs(u64::MAX), UTCTimestamp::ZERO);
+    assert_eq!(timestamp.saturating_sub_millis(1000), timestamp.saturating_sub_secs(1));
+    assert_eq!(timestamp.saturating_sub_micros(1000), timestamp.saturating_sub_millis(1));
+    assert_eq!(timestamp.saturating_sub_nanos(1000), timestamp.saturating_sub_micros(1));
+    assert_eq!(timestamp.saturating_mul(u32::MIN), UTCTimestamp::ZERO);
+    assert_eq!(timestamp.saturating_mul(u32::MAX).saturating_mul(u32::MAX), UTCTimestamp::MAX);
+    assert_eq!(timestamp.checked_div(u32::MAX).unwrap().checked_div(u32::MAX), Some(UTCTimestamp::ZERO));
+    assert_eq!(timestamp.checked_div(u32::MIN), None);
+    // test operation implementations
+    let one = UTCTimestamp::from_nanos(1);
+    let two = UTCTimestamp::from_nanos(2);
+    assert_eq!(one + one, two);
+    assert_eq!(two - one, one);
+    assert_eq!(two * 1, two);
+    assert_eq!(1 * two, two);
+    assert_eq!(two / 2, one);
+    let mut assign = UTCTimestamp::ZERO;
+    assign += two;
+    assert_eq!(assign, two);
+    assign -= one;
+    assert_eq!(assign, one);
+    assign *= 2;
+    assert_eq!(assign, two);
+    assign /= 2;
+    assert_eq!(assign, one);
     Ok(())
 }
 
@@ -163,6 +198,42 @@ fn test_utc_day() -> Result<()> {
     assert_eq!(utc_day_copy, utc_day);
     assert_eq!(UTCDay::ZERO, utc_day_copy.min(UTCDay::ZERO));
     assert_eq!(UTCDay::MAX, utc_day_copy.max(UTCDay::MAX));
+    // test operation methods
+    assert_eq!(utc_day.saturating_add(UTCDay::ZERO), utc_day);
+    assert_eq!(utc_day.saturating_add(UTCDay::MAX), UTCDay::MAX);
+    assert_eq!(utc_day.saturating_add(unsafe { UTCDay::from_u64_unchecked(u64::MAX) }), UTCDay::MAX);
+    assert_eq!(utc_day.saturating_add_u64(0), utc_day);
+    assert_eq!(utc_day.saturating_add_u64(u64::MAX), UTCDay::MAX);
+    assert_eq!(utc_day.saturating_sub(UTCDay::ZERO), utc_day);
+    assert_eq!(utc_day.saturating_sub(UTCDay::MAX), UTCDay::ZERO);
+    assert_eq!(utc_day.saturating_sub_u64(0), utc_day);
+    assert_eq!(utc_day.saturating_sub_u64(u64::MAX), UTCDay::ZERO);
+    assert_eq!(utc_day.saturating_mul(u64::MIN), UTCDay::ZERO);
+    assert_eq!(utc_day.saturating_mul(u64::MAX), UTCDay::MAX);
+    assert_eq!(utc_day.checked_div(u64::MAX), Some(UTCDay::ZERO));
+    assert_eq!(utc_day.checked_div(u64::MIN), None);
+    // test operation implementations
+    let one = UTCDay::try_from_u64(1)?;
+    let two = UTCDay::try_from_u64(2)?;
+    let three = UTCDay::try_from_u64(3)?;
+    assert_eq!(one + one, two);
+    assert_eq!(one + 1, two);
+    assert_eq!(two - one, one);
+    assert_eq!(two - 1, one);
+    assert_eq!(two * 1, two);
+    assert_eq!(1 * two, two);
+    assert_eq!(two / 2, one);
+    let mut assign = UTCDay::ZERO;
+    assign += 1;
+    assign += two;
+    assert_eq!(assign, three);
+    assign -= one;
+    assign -= 1;
+    assert_eq!(assign, one);
+    assign *= 2;
+    assert_eq!(assign, two);
+    assign /= 2;
+    assert_eq!(assign, one);
     Ok(())
 }
 

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -111,35 +111,84 @@ fn test_utc_timestamp() -> Result<()> {
     assert_eq!(UTCTimestamp::MAX, timestamp_copy.max(UTCTimestamp::MAX));
     // test operation methods
     assert_eq!(timestamp.saturating_add(UTCTimestamp::ZERO), timestamp);
-    assert_eq!(timestamp.saturating_add(UTCTimestamp::MAX), UTCTimestamp::MAX);
+    assert_eq!(
+        timestamp.saturating_add(UTCTimestamp::MAX),
+        UTCTimestamp::MAX
+    );
+    assert_eq!(timestamp.saturating_add_duration(Duration::ZERO), timestamp);
+    assert_eq!(
+        timestamp.saturating_add_duration(Duration::MAX),
+        UTCTimestamp::MAX
+    );
     assert_eq!(timestamp.saturating_add_secs(0), timestamp);
     assert_eq!(timestamp.saturating_add_secs(u64::MAX), UTCTimestamp::MAX);
-    assert_eq!(timestamp.saturating_add_millis(1000), timestamp.saturating_add_secs(1));
-    assert_eq!(timestamp.saturating_add_micros(1000), timestamp.saturating_add_millis(1));
-    assert_eq!(timestamp.saturating_add_nanos(1000), timestamp.saturating_add_micros(1));
+    assert_eq!(
+        timestamp.saturating_add_millis(1000),
+        timestamp.saturating_add_secs(1)
+    );
+    assert_eq!(
+        timestamp.saturating_add_micros(1000),
+        timestamp.saturating_add_millis(1)
+    );
+    assert_eq!(
+        timestamp.saturating_add_nanos(1000),
+        timestamp.saturating_add_micros(1)
+    );
     assert_eq!(timestamp.saturating_sub(UTCTimestamp::ZERO), timestamp);
-    assert_eq!(timestamp.saturating_sub(UTCTimestamp::MAX), UTCTimestamp::ZERO);
+    assert_eq!(
+        timestamp.saturating_sub(UTCTimestamp::MAX),
+        UTCTimestamp::ZERO
+    );
+    assert_eq!(timestamp.saturating_sub_duration(Duration::ZERO), timestamp);
+    assert_eq!(
+        timestamp.saturating_sub_duration(Duration::MAX),
+        UTCTimestamp::ZERO
+    );
     assert_eq!(timestamp.saturating_sub_secs(0), timestamp);
     assert_eq!(timestamp.saturating_sub_secs(u64::MAX), UTCTimestamp::ZERO);
-    assert_eq!(timestamp.saturating_sub_millis(1000), timestamp.saturating_sub_secs(1));
-    assert_eq!(timestamp.saturating_sub_micros(1000), timestamp.saturating_sub_millis(1));
-    assert_eq!(timestamp.saturating_sub_nanos(1000), timestamp.saturating_sub_micros(1));
+    assert_eq!(
+        timestamp.saturating_sub_millis(1000),
+        timestamp.saturating_sub_secs(1)
+    );
+    assert_eq!(
+        timestamp.saturating_sub_micros(1000),
+        timestamp.saturating_sub_millis(1)
+    );
+    assert_eq!(
+        timestamp.saturating_sub_nanos(1000),
+        timestamp.saturating_sub_micros(1)
+    );
     assert_eq!(timestamp.saturating_mul(u32::MIN), UTCTimestamp::ZERO);
-    assert_eq!(timestamp.saturating_mul(u32::MAX).saturating_mul(u32::MAX), UTCTimestamp::MAX);
-    assert_eq!(timestamp.checked_div(u32::MAX).unwrap().checked_div(u32::MAX), Some(UTCTimestamp::ZERO));
+    assert_eq!(
+        timestamp.saturating_mul(u32::MAX).saturating_mul(u32::MAX),
+        UTCTimestamp::MAX
+    );
+    assert_eq!(
+        timestamp
+            .checked_div(u32::MAX)
+            .unwrap()
+            .checked_div(u32::MAX),
+        Some(UTCTimestamp::ZERO)
+    );
     assert_eq!(timestamp.checked_div(u32::MIN), None);
     // test operation implementations
     let one = UTCTimestamp::from_nanos(1);
     let two = UTCTimestamp::from_nanos(2);
+    let three = UTCTimestamp::from_nanos(3);
+    let one_duration = Duration::from_nanos(1);
     assert_eq!(one + one, two);
+    assert_eq!(one + one_duration, two);
     assert_eq!(two - one, one);
+    assert_eq!(two - one_duration, one);
     assert_eq!(two * 1, two);
     assert_eq!(1 * two, two);
     assert_eq!(two / 2, one);
     let mut assign = UTCTimestamp::ZERO;
+    assign += one_duration;
     assign += two;
-    assert_eq!(assign, two);
+    assert_eq!(assign, three);
     assign -= one;
+    assign -= one_duration;
     assert_eq!(assign, one);
     assign *= 2;
     assert_eq!(assign, two);
@@ -201,7 +250,10 @@ fn test_utc_day() -> Result<()> {
     // test operation methods
     assert_eq!(utc_day.saturating_add(UTCDay::ZERO), utc_day);
     assert_eq!(utc_day.saturating_add(UTCDay::MAX), UTCDay::MAX);
-    assert_eq!(utc_day.saturating_add(unsafe { UTCDay::from_u64_unchecked(u64::MAX) }), UTCDay::MAX);
+    assert_eq!(
+        utc_day.saturating_add(unsafe { UTCDay::from_u64_unchecked(u64::MAX) }),
+        UTCDay::MAX
+    );
     assert_eq!(utc_day.saturating_add_u64(0), utc_day);
     assert_eq!(utc_day.saturating_add_u64(u64::MAX), UTCDay::MAX);
     assert_eq!(utc_day.saturating_sub(UTCDay::ZERO), utc_day);


### PR DESCRIPTION
The `UTCTimestamp` and `UTCDay` types are often manipulated in user code. Prior to this merge this would often require "unwrapping" the underlying types (`Duration` and `u64` respectively), then applying the operations, and wrapping back to the `utc_dt` type.

With this PR we provide `checked_` and `saturated_` methods for operating on these types directly, as well as implementations for the standard math operators (`Add`, `AddAssign`, `Sub`, `SubAssign`, `Mul`, `MulAssign`, `Div`, `DivAssign`). 