### PR TITLE
Bump Rust version for error in core feature, remove nightly feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,11 +54,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install Rust
-      run: rustup update nightly
+      run: rustup update
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage
-      run: cargo +nightly llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utc-dt"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Reece Kibble <reecek@uniciant.com>"]
 categories = ["date-and-time", "no-std", "parsing"]
 keywords = ["time", "datetime", "date", "utc", "epoch"]
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/utc-dt"
 repository = "https://github.com/uniciant/utc-datetime"
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.81"
 readme = "README.md"
 exclude = [".git*"]
 
@@ -23,7 +23,6 @@ std = [
 ]
 alloc = ["serde/alloc"]
 serde = ["dep:serde"]
-nightly = []
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ The [`std`, `alloc`] feature flags are enabled by default.
 - `std`: Enables methods that use the system clock via `std::time::SystemTime`. Enables `alloc`.
 - `alloc`: Enables methods that use allocated strings.
 - `serde`: Derives `serde::Serialize` and `serde::Deserialize` for all internal non-error types.
-- `nightly`: Enables the unstable [`error_in_core`](https://github.com/rust-lang/rust/issues/103765) feature for improved `#[no_std]` error handling.
 
 ## References
 - [(Howard Hinnant, 2021) `chrono`-Compatible Low-Level Date Algorithms](http://howardhinnant.github.io/date_algorithms.html)

--- a/src/date.rs
+++ b/src/date.rs
@@ -6,18 +6,13 @@
 
 use crate::time::{UTCDay, UTCTimestamp, UTCTransformations};
 use crate::util::StrWriter;
+use core::error::Error;
 use core::fmt::{Display, Formatter, Write};
 use core::num::ParseIntError;
 use core::time::Duration;
 
 #[cfg(feature = "alloc")]
 use alloc::{format, string::String};
-
-// TODO <https://github.com/rust-lang/rust/issues/103765>
-#[cfg(feature = "nightly")]
-use core::error::Error;
-#[cfg(all(feature = "std", not(feature = "nightly")))]
-use std::error::Error;
 
 /// UTC Date.
 ///
@@ -394,7 +389,6 @@ impl Display for UTCDateError {
     }
 }
 
-#[cfg(any(feature = "std", feature = "nightly"))]
 impl Error for UTCDateError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,6 @@
 //! - `std`: Enables methods that use the system clock via `std::time::SystemTime`. Enables `alloc`.
 //! - `alloc`: Enables methods that use allocated strings.
 //! - `serde`: Derives `serde::Serialize` and `serde::Deserialize` for all internal non-error types.
-//! - `nightly`: Enables the unstable [`error_in_core`](https://github.com/rust-lang/rust/issues/103765) feature for improved `#[no_std]` error handling.
 //!
 //! ## References
 //! - [(Howard Hinnant, 2021) `chrono`-Compatible Low-Level Date Algorithms](http://howardhinnant.github.io/date_algorithms.html)
@@ -217,9 +216,6 @@
 #![warn(missing_debug_implementations)]
 #![warn(dead_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
-// TODO <https://github.com/rust-lang/rust/issues/103765>
-// Releasing in stable rust 1.81.0, 5th september!
-#![cfg_attr(all(not(feature = "std"), feature = "nightly"), feature(error_in_core))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -232,6 +228,7 @@ mod util;
 
 use crate::date::{UTCDate, UTCDateError};
 use crate::time::{UTCTimeOfDay, UTCTimeOfDayError, UTCTimestamp, UTCTransformations};
+use core::error::Error;
 use core::fmt::{Display, Formatter};
 use core::time::Duration;
 
@@ -239,12 +236,6 @@ use core::time::Duration;
 use alloc::string::String;
 use time::UTCDayErrOutOfRange;
 use util::StrWriter;
-
-// TODO <https://github.com/rust-lang/rust/issues/103765>
-#[cfg(feature = "nightly")]
-use core::error::Error;
-#[cfg(all(feature = "std", not(feature = "nightly")))]
-use std::error::Error;
 
 /// UTC Datetime.
 ///
@@ -473,7 +464,6 @@ impl Display for UTCDatetimeError {
     }
 }
 
-#[cfg(any(feature = "std", feature = "nightly"))]
 impl Error for UTCDatetimeError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
@@ -520,7 +510,6 @@ impl Display for UTCError {
     }
 }
 
-#[cfg(any(feature = "std", feature = "nightly"))]
 impl Error for UTCError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,6 +4,7 @@
 
 use crate::constants::*;
 use crate::util::StrWriter;
+use core::error::Error;
 use core::fmt::{Display, Formatter, Write};
 use core::num::ParseIntError;
 use core::ops::*;
@@ -14,12 +15,6 @@ use alloc::{format, string::String};
 
 #[cfg(feature = "std")]
 use std::time::{SystemTime, SystemTimeError};
-
-// TODO <https://github.com/rust-lang/rust/issues/103765>
-#[cfg(feature = "nightly")]
-use core::error::Error;
-#[cfg(all(feature = "std", not(feature = "nightly")))]
-use std::error::Error;
 
 /// UTC Timestamp.
 ///
@@ -796,7 +791,6 @@ impl Display for UTCDayErrOutOfRange {
     }
 }
 
-#[cfg(any(feature = "std", feature = "nightly"))]
 impl Error for UTCDayErrOutOfRange {}
 
 impl UTCTransformations for UTCDay {
@@ -1339,7 +1333,6 @@ impl Display for UTCTimeOfDayError {
     }
 }
 
-#[cfg(any(feature = "std", feature = "nightly"))]
 impl Error for UTCTimeOfDayError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@ impl<'a> StrWriter<'a> {
     }
 }
 
-impl<'a> core::fmt::Write for StrWriter<'a> {
+impl core::fmt::Write for StrWriter<'_> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         let remaining = self.buf.len() - self.written;
         let write_len = remaining.min(s.len());


### PR DESCRIPTION
Bump Rust version to 1.81 for the stabilized `error_in_core` feature.